### PR TITLE
Fix build rate tail end calculation

### DIFF
--- a/cia/plot.py
+++ b/cia/plot.py
@@ -137,9 +137,20 @@ class PlotBuildrate(Plot):
             # samples (expose via cli arg).
             legendlist.append(f"{descr}, rolling window mean ({self.wwd} days)")
 
-            rolling_build_rate = analysis.calc_rolling_event_rate(
-                df.index.to_series(), window_width_seconds=86400 * self.wwd
-            )
+            # special-case: rely on "all builds" key to exist; treat that
+            # time series differently from all others: assume that all others
+            # are, each, a subset of all builds.
+            if descr == "all builds":
+                rolling_build_rate = analysis.calc_rolling_event_rate(
+                    df.index.to_series(), window_width_seconds=86400 * self.wwd
+                )
+            else:
+                rolling_build_rate = analysis.calc_rolling_event_rate(
+                    df.index.to_series(),
+                    window_width_seconds=86400 * self.wwd,
+                    upsample_with_zeros=True,
+                    upsample_with_zeros_until=self.builds_map["all builds"].index.max(),
+                )
 
             log.info("Plot build rate: window width (days): %s", self.wwd)
 


### PR DESCRIPTION
With https://github.com/jgehrcke/ci-analysis/pull/6 came new artifacts.

The forward-fill introduced with #6 operated in a series-local fashion. As of that, the rolling window aggregate series for "passed builds" was able to -- for certain points in time at the tail end -- exceed the value of the corresponding rolling window aggregate series for "all builds". This is obviously wrong by definition, because the passed builds are a subset of all builds; and therefore the rate of the former must never exceed the rate of the latter. (another obvious symptom here was the stability metric exceeding 1 -- clearly verboten):

![Screenshot from 2020-12-10 13-28-39](https://user-images.githubusercontent.com/265630/101772474-b0086d80-3aeb-11eb-8727-475c92da60c1.png)


This current patch makes things correct again around the tail end:

![Screenshot from 2020-12-10 13-30-22](https://user-images.githubusercontent.com/265630/101772711-037abb80-3aec-11eb-8cb4-71c726af13d7.png)

The forward-fill by half the time width of the rolling window towards the end of the series is explained in code comments -- a trade-off between 
- not breaking symmetry of the original time series data
- and also showing an aggregate value for "now" / the latest point in time of the original (non-aggregated) data set



