### PR TITLE
Fixes and tweaks found while testing a different pipeline

### DIFF
--- a/cia/buildkite.py
+++ b/cia/buildkite.py
@@ -60,6 +60,7 @@ def main():
         load_all_builds(CFG().args.org, CFG().args.pipeline, [BuildState.FINISHED])
     )
 
+    builds = bfilter.drop_builds_that_did_not_start(builds)
 
     builds = bfilter.filter_builds_based_on_build_time(builds)
 

--- a/cia/buildkite.py
+++ b/cia/buildkite.py
@@ -56,27 +56,27 @@ _PLOTS_FOR_SUBPLOTS = []
 
 def main():
 
-    builds_all = rewrite_build_objects(
+    builds = rewrite_build_objects(
         load_all_builds(CFG().args.org, CFG().args.pipeline, [BuildState.FINISHED])
     )
 
-    # Store this under "all", although these are technically already filtered
-    builds_all = bfilter.filter_builds_based_on_build_time(builds_all)
 
-    build_numbers = sorted([b["number"] for b in builds_all])
+    builds = bfilter.filter_builds_based_on_build_time(builds)
+
+    build_numbers = sorted([b["number"] for b in builds])
     log.info("build numbers: %s ... %s", build_numbers[0:5], build_numbers[-5:-1])
 
-    set_common_x_limit_for_plotting(builds_all)
+    set_common_x_limit_for_plotting(builds)
 
     plot.matplotlib_config()
 
     builds_passed = bfilter.filter_builds_passed(
-        bfilter.filter_builds_based_on_duration(builds_all)
+        bfilter.filter_builds_based_on_duration(builds)
     )
 
     p = plot.PlotBuildrate(
         builds_map={
-            "all builds": construct_df_for_builds(builds_all),
+            "all builds": construct_df_for_builds(builds),
             "passed builds": construct_df_for_builds(builds_passed),
         },
         window_width_days=4,
@@ -85,9 +85,9 @@ def main():
     p.plot_mpl_singlefig()
     _PLOTS_FOR_SUBPLOTS.append(p)
 
-    analyze_build_stability(builds_all, builds_passed, window_width_days=4)
+    analyze_build_stability(builds, builds_passed, window_width_days=4)
 
-    analyze_passed_builds(builds_all)
+    analyze_passed_builds(builds)
 
     create_summary_fig_with_subplots()
 

--- a/cia/buildkite.py
+++ b/cia/buildkite.py
@@ -60,7 +60,7 @@ def main():
         load_all_builds(CFG().args.org, CFG().args.pipeline, [BuildState.FINISHED])
     )
 
-    builds = bfilter.drop_builds_that_did_not_start(builds)
+    builds = bfilter.drop_builds_that_did_not_start_or_finish(builds)
 
     builds = bfilter.filter_builds_based_on_build_time(builds)
 

--- a/cia/buildkite.py
+++ b/cia/buildkite.py
@@ -28,7 +28,6 @@ import os
 import logging
 import sys
 import time
-import json
 from collections import Counter, defaultdict
 from datetime import datetime
 
@@ -151,10 +150,15 @@ def create_summary_fig_with_subplots():
     # plt.show()
 
 
-def set_common_x_limit_for_plotting(builds_all):
-    # Get earliest and latest builds (their "time")
-    # Rely on result df of this func to be sorted by time: past -> future
-    df = construct_df_for_builds(builds_all)
+def set_common_x_limit_for_plotting(builds):
+    # Get earliest and latest build.  Rely on result df of this func to be
+    # sorted by time: past -> future
+    df = construct_df_for_builds(builds)
+
+    log.info('common_x_limit_for_plotting -- df:\n%s', df)
+    log.info("common_x_limit_for_plotting -- df.index[0]: %s", df.index[0])
+    log.info("common_x_limit_for_plotting -- df.index[-1]: %s", df.index[-1])
+
     mintime_across_builds = df.index[0]
     maxtime_across_builds = df.index[-1]
     diff = maxtime_across_builds - mintime_across_builds
@@ -309,7 +313,8 @@ def construct_df_for_jobs(jobs):
 
 def construct_df_for_builds(builds, jobs=False, ignore_builds=None):
 
-    log.info("build pandas dataframe for passed builds")
+    log.info("build pandas dataframe for builds")
+
     df_dict = {
         "started_at": [b["started_at"] for b in builds],
         "build_number": [b["number"] for b in builds],

--- a/cia/filter.py
+++ b/cia/filter.py
@@ -29,9 +29,18 @@ from .cfg import CFG
 log = logging.getLogger(__name__)
 
 
+def drop_builds_that_did_not_start(builds):
+    kept = []
+    for b in builds:
+        if b['started_at'] is None:
+            log.info('build did not start, drop: %s', b['number'])
+            continue
+        kept.append(b)
+    return kept
+
+
 def filter_builds_based_on_build_time(builds):
     builds_kept = builds
-
     if CFG().args.ignore_builds_before:
         # tz-naive
         earliest_date = datetime.strptime(CFG().args.ignore_builds_before, "%Y-%m-%d")
@@ -48,7 +57,6 @@ def filter_builds_based_on_build_time(builds):
 
 
 def filter_builds_based_on_duration(builds):
-
     builds_kept = builds
 
     if CFG().args.ignore_builds_shorter_than:

--- a/cia/filter.py
+++ b/cia/filter.py
@@ -29,11 +29,14 @@ from .cfg import CFG
 log = logging.getLogger(__name__)
 
 
-def drop_builds_that_did_not_start(builds):
+def drop_builds_that_did_not_start_or_finish(builds):
     kept = []
     for b in builds:
         if b['started_at'] is None:
             log.info('build did not start, drop: %s', b['number'])
+            continue
+        if b['finished_at'] is None:
+            log.info('build did not finish, drop: %s', b['number'])
             continue
         kept.append(b)
     return kept

--- a/cia/plot.py
+++ b/cia/plot.py
@@ -311,7 +311,7 @@ class PlotDuration(Plot):
         # text coords: x, y
         ax.text(
             0.01,
-            0.04,
+            0.05,
             self.context_descr,
             fontsize=_CONTEXT_LABEL_FONTSIZE,
             transform=ax.transAxes,

--- a/cia/plot.py
+++ b/cia/plot.py
@@ -116,7 +116,7 @@ class PlotStability(Plot):
             transform=ax.transAxes,
             color=_CONTEXT_LABEL_FONTCOLOR,
         )
-        ax.set_ylim(0, 1.15)
+        ax.set_ylim(-0.15, 1.15)
 
 
 class PlotBuildrate(Plot):
@@ -301,7 +301,7 @@ class PlotDuration(Plot):
 
         # To put the duration into perspective: make sure to show the lower
         # end, the zero, by default. Maybe do a common y max limit alter.
-        ax.set_ylim((0, ax.get_ylim()[1] * 1.2))
+        ax.set_ylim((-0.09, ax.get_ylim()[1] * 1.2))
 
         if self.xlabel is None:
             ax.set_xlabel("build start time", fontsize=10)

--- a/cia/plot.py
+++ b/cia/plot.py
@@ -40,8 +40,8 @@ log = logging.getLogger(__name__)
 
 _GLOBAL_X_LIMIT = None
 _Y_LABEL_FONTSIZE = 7
-_CONTEXT_LABEL_FONTSIZE = 7
-
+_CONTEXT_LABEL_FONTSIZE = 6
+_CONTEXT_LABEL_FONTCOLOR = "#444444"
 
 class Plot(ABC):
 
@@ -114,7 +114,7 @@ class PlotStability(Plot):
             self.context_descr,
             fontsize=_CONTEXT_LABEL_FONTSIZE,
             transform=ax.transAxes,
-            color="#666666",
+            color=_CONTEXT_LABEL_FONTCOLOR,
         )
         ax.set_ylim(0, 1.15)
 
@@ -200,7 +200,7 @@ class PlotBuildrate(Plot):
             self.context_descr,
             fontsize=_CONTEXT_LABEL_FONTSIZE,
             transform=ax.transAxes,
-            color="#666666",
+            color=_CONTEXT_LABEL_FONTCOLOR,
         )
 
 
@@ -315,7 +315,7 @@ class PlotDuration(Plot):
             self.context_descr,
             fontsize=_CONTEXT_LABEL_FONTSIZE,
             transform=ax.transAxes,
-            color="#666666",
+            color=_CONTEXT_LABEL_FONTCOLOR,
         )
 
         log.debug("_plot_mpl_core END: ax: %s", id(ax))

--- a/cia/plot.py
+++ b/cia/plot.py
@@ -320,7 +320,7 @@ class PlotDuration(Plot):
 
         log.debug("_plot_mpl_core END: ax: %s", id(ax))
 
-        ax.legend(legendlist, numpoints=4)
+        ax.legend(legendlist, numpoints=4, loc='upper left')
 
         if self.ylog:
             # untested so far


### PR DESCRIPTION
Real-world data sets are always noisy and present interesting edge cases. While testing with a specific buildkite pipeline I found that a _finished_ build may not have a 'start time' tied to it -- when it was scheduled to be started but never actually started, e.g. as of a lack of an available build agent.